### PR TITLE
Fix filtering completions

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -178,6 +178,8 @@ export function createCompletionSource(options: createCompletionSource.Options):
     }
 
     const completionOptions: Completion[] = []
+    let minFrom = context.pos
+    let maxTo = context.pos + 1
 
     for (const item of items) {
       const { commitCharacters, detail, documentation, kind, label, textEdit, textEditText } = item
@@ -196,6 +198,12 @@ export function createCompletionSource(options: createCompletionSource.Options):
         const range = 'range' in textEdit ? textEdit.range : textEdit.replace
         const from = textDocument.offsetAt(range.start)
         const to = textDocument.offsetAt(range.end)
+        if (from < minFrom) {
+          minFrom = from
+        }
+        if (to > maxTo) {
+          maxTo = to
+        }
         const insert = textEdit.newText
         const insertTextFormat = item.insertTextFormat ?? itemDefaults?.insertTextFormat
 
@@ -211,7 +219,8 @@ export function createCompletionSource(options: createCompletionSource.Options):
     }
 
     return {
-      from: context.pos,
+      from: minFrom,
+      to: maxTo,
       commitCharacters: itemDefaults?.commitCharacters,
       options: completionOptions
     }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -179,7 +179,7 @@ export function createCompletionSource(options: createCompletionSource.Options):
 
     const completionOptions: Completion[] = []
     let minFrom = context.pos
-    let maxTo = context.pos + 1
+    let maxTo = context.pos
 
     for (const item of items) {
       const { commitCharacters, detail, documentation, kind, label, textEdit, textEditText } = item

--- a/test/completion.test.ts
+++ b/test/completion.test.ts
@@ -213,7 +213,8 @@ test('minimal meta', async () => {
         section: undefined,
         type: undefined
       }
-    ]
+    ],
+    to: 4
   })
 })
 
@@ -249,7 +250,8 @@ test('full meta', async () => {
         section: undefined,
         type: undefined
       }
-    ]
+    ],
+    to: 3
   })
 
   const completion = completions!.options[0]!
@@ -581,7 +583,8 @@ test('completion item kinds', async () => {
         section: undefined,
         type: 'type'
       }
-    ]
+    ],
+    to: 3
   })
 })
 
@@ -616,7 +619,8 @@ test('textEditText', async () => {
         section: undefined,
         type: undefined
       }
-    ]
+    ],
+    to: 3
   })
 })
 
@@ -632,9 +636,19 @@ test('textEdit plain text', async () => {
       yield {
         label: 'completion',
         textEdit: {
-          newText: 'pletion',
+          newText: 'Completion',
           range: {
-            start: { line: 0, character: 3 },
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 5 }
+          }
+        }
+      }
+      yield {
+        label: 'completion',
+        textEdit: {
+          newText: 'Completion',
+          range: {
+            start: { line: 0, character: 0 },
             end: { line: 0, character: 5 }
           }
         }
@@ -647,6 +661,8 @@ test('textEdit plain text', async () => {
   const apply = completions!.options[0]!.apply as (v: EditorView) => unknown
   apply(view)
 
+  expect(completions?.from).toBe(0)
+  expect(completions?.to).toBe(5)
   expect(String(view.state.doc)).toBe('Completion\n')
 })
 


### PR DESCRIPTION
This fixes filtering of completions by specifying the `from` and `to` fields based on the completion items.

Closes #4